### PR TITLE
screen: initial implementation of virtual screen

### DIFF
--- a/include/avtka.h
+++ b/include/avtka.h
@@ -80,6 +80,23 @@ uint8_t avtka_register_colour(struct avtka_t *avtka,
 /* Quit and cleanup a ui */
 int32_t avtka_destroy(struct avtka_t *a);
 
+struct avtka_screen_opts_t {
+	uint16_t x, y, w, h;
+	uint16_t px_x, px_y;
+	/* single bit per pixel; on off only */
+	uint32_t flags_1bit : 1;
+	/* rgb capable screen */
+	uint32_t flags_rgb  : 1;
+};
+
+/* allocate a new screen in the UI.
+ * Returns 0 or a positive number as the screen-id on success.
+ * Returns -1 on invalid screen_opts, or  failure to allocate memory
+ */
+int32_t
+avtka_screen_create(struct avtka_t *a, struct avtka_screen_opts_t *opts);
+uint8_t *avtka_screen_get_data_ptr(struct avtka_t *a, uint16_t screen_id);
+
 /* Set visibility of the text label */
 void avtka_item_label_show(struct avtka_t *a, uint32_t item, uint32_t show);
 /* Set value of the item */

--- a/meson.build
+++ b/meson.build
@@ -21,7 +21,7 @@ avtka_includes += include_directories('include')
 avtka_includes += include_directories('src')
 avtka_src = []
 
-src_files  = ['avtka.c', 'item.c', 'draw.c', 'interact.c']
+src_files  = ['avtka.c', 'screen.c', 'item.c', 'draw.c', 'interact.c']
 src_files += ['pugl/pugl_x11.c']
 
 foreach file : src_files

--- a/src/avtka.c
+++ b/src/avtka.c
@@ -95,6 +95,25 @@ on_display(PuglView* view)
 	cairo_rectangle(cr, 0, 0, a->opts.w, a->opts.h);
 	cairo_fill(cr);
 
+	/* paint screens to the UI */
+	for (int i = 0; i < a->screen_count; i++) {
+		cairo_surface_t *s = a->screen_surfaces[i];
+		int x = a->screen_opts[i].x;
+		int y = a->screen_opts[i].y;
+#if 0
+		cairo_t *scr = cairo_create(s);
+		cairo_set_source_rgba(scr, 1, 1, 1, 1);
+		cairo_rectangle(scr, 0,0, 128, 64);
+		cairo_stroke(scr);
+		cairo_surface_flush(s);
+		cairo_destroy(scr);
+#endif
+
+		cairo_surface_flush(s);
+		cairo_set_source_surface(cr, s, x, y);
+		cairo_paint(cr);
+	}
+
 	/* iterate all items, calling "draw" on them */
 	for (int i = 0; i < a->item_count; i++) {
 		uint8_t draw_id = a->items[i].opts.draw;

--- a/src/impl.h
+++ b/src/impl.h
@@ -23,6 +23,7 @@
 
 #define AVTKA_MAX_ITEMS 1024
 #define AVTKA_MAX_DRAW 8
+#define AVTKA_MAX_SCREENS 2
 
 struct avtka_item_t {
 	/* public state of widget */
@@ -49,7 +50,6 @@ int32_t avtka_interact_release(struct avtka_t *a, uint32_t item,
 int32_t avtka_interact_motion(struct avtka_t *a, uint32_t item,
 			      int32_t x, int32_t y);
 
-
 struct avtka_t {
 	struct avtka_opts_t opts;
 
@@ -65,6 +65,11 @@ struct avtka_t {
 	/* all items in the UI */
 	uint32_t item_count;
 	struct avtka_item_t items[AVTKA_MAX_ITEMS];
+
+	/* virtual screen surfaces */
+	uint16_t screen_count;
+	void *screen_surfaces[AVTKA_MAX_SCREENS];
+	struct avtka_screen_opts_t screen_opts[AVTKA_MAX_SCREENS];
 
 	/* array of draw routines */
 	avtka_draw draw[AVTKA_MAX_DRAW];

--- a/src/screen.c
+++ b/src/screen.c
@@ -34,7 +34,6 @@ avtka_screen_create(struct avtka_t *a, struct avtka_screen_opts_t *o)
 
 	a->screen_count++;
 
-
 	return screen_id;
 }
 

--- a/src/screen.c
+++ b/src/screen.c
@@ -1,0 +1,48 @@
+/* This file is part of AVTKA by OpenAV */
+
+#include <stdio.h>
+
+#include "impl.h"
+
+#include <cairo/cairo.h>
+
+int32_t
+avtka_screen_create(struct avtka_t *a, struct avtka_screen_opts_t *o)
+{
+	/* add a new screen to the UI here */
+	printf("creating screen %d, pixel size %d %d\n", a->screen_count,
+	       o->px_x, o->px_y);
+
+	cairo_surface_t *img;
+
+	/* TODO: rework the creation based on HW device capabilities.
+	 * Note that the *BINARY* interface of the *HARDWARE CONTROLLER*
+	 * should be simulated here. Even if this means looping through
+	 * each and every pixel - the same API as is exposed to draw on
+	 * the HW must be functioning on the virtual display */
+#if 0
+	if(o->flags_1bit) {
+		img = cairo_image_surface_create(CAIRO_FORMAT_A1, 128, 64);
+	}
+	else
+#endif
+	img = cairo_image_surface_create(CAIRO_FORMAT_RGB24, 128, 64);
+
+	int screen_id = a->screen_count;
+	a->screen_surfaces[screen_id] = img;
+	a->screen_opts[screen_id] = *o;
+
+	a->screen_count++;
+
+
+	return screen_id;
+}
+
+uint8_t *
+avtka_screen_get_data_ptr(struct avtka_t *a, uint16_t screen_id)
+{
+	cairo_surface_t *s = a->screen_surfaces[screen_id];
+	uint8_t *data = cairo_image_surface_get_data(s);
+	return data;
+}
+


### PR DESCRIPTION
This commit adds a new concept to the AVTKA library, allowing
a "screen" to be created. The screen represents a physical
screen on a controller, allowing a developer to prototype and
test the integration with the device's screen.

Currently there are still some hard-coded constants and
assumptions in the code. These will remain until a decision
is made on how to present the screens.

There are two main choices:
1) Application draws in a known format (ARGB32 or somthing). Apps can
   use eg: Cairo, and the Ctlra library accepts a pixel array, which
   it transforms into the binary stream the device expects.
2) The Application gets raw-access to the binary stream, and must decode
   or otherwise fixup the correct byte layout for the device.

There is a compromise available, where the raw pointer to the data is
exposed, but Ctlra *ALSO* provides a helper function that just accepts
RGB24 data, and converts to the data-format as required by the hw instance.

Signed-off-by: Harry van Haaren <harryhaaren@gmail.com>